### PR TITLE
Bugs correction and reworks

### DIFF
--- a/admin_config.php
+++ b/admin_config.php
@@ -13,6 +13,8 @@ e107::lan('glossary','admin',true);
 e107::lan('glossary','help',true);
 e107::lan('glossary','class',true);
 
+require_once(e_PLUGIN.'glossary/glossary_trait.php');
+
 class glossary_adminArea extends e_admin_dispatcher
 {
 
@@ -80,6 +82,7 @@ class glossary_adminArea extends e_admin_dispatcher
 
 class glossary_ui extends e_admin_ui
 {
+    use GlossaryTrait;
 			
 		protected $pluginTitle		= 'Glossary';
 		protected $pluginName		= 'glossary';
@@ -123,12 +126,19 @@ class glossary_ui extends e_admin_ui
 		public function init()
 		{
 			// Set drop-down values (if any). 
-    require_once(e_PLUGIN.'glossary/glossary_class.php');
-    $gc = new glossary_class();
+//    require_once(e_PLUGIN.'glossary/glossary_class.php');
+//    $gc = new glossary_class();
+
+//var_dump(e107::getPlugPref('glossary','glossary_submit_htmlarea'));
+
+    if (e107::getPlugPref('glossary','glossary_submit_htmlarea'))
+  		$this->fields['glo_description']['type'] = 'bbarea';
     
 //    var_dump($gc);
-    $this->postFiliterMarkup = $gc->show_letter(1);
-
+//    $this->postFiliterMarkup = $gc->show_letter(1);
+    $this->postFiliterMarkup = $this->browse_letter(1);
+//    $this->postFiliterMarkup = 	$gc->displayWords();
+    
 		$tp = e107::getParser();
     $letter = (isset($_GET['letter']) ? $_GET['letter'] : "");
 		if ($letter != "" && $letter != LAN_GLOSSARY_SHOWLETT_02 )
@@ -198,11 +208,12 @@ class glossary_submitted_ui extends glossary_ui
 	public function init()
 	{
 			// Set drop-down values (if any). 
-    require_once(e_PLUGIN.'glossary/glossary_class.php');
-    $gc = new glossary_class();
+//    require_once(e_PLUGIN.'glossary/glossary_class.php');
+//    $gc = new glossary_class();
     
 //    var_dump($gc);
-    $this->postFiliterMarkup = $gc->show_letter(0);
+//    $this->postFiliterMarkup = $gc->show_letter(0);
+    $this->postFiliterMarkup = $this->browse_letter(0);
 
 //    var_dump($_POST);
 //    var_dump($_GET);
@@ -229,7 +240,7 @@ class glossary_general_ui extends e_admin_ui
 
   	protected $prefs = array( 
   					'glossary_linkword'  => array('title'=> LAN_GLOSSARY_OPTGEN_05,'type' => 'boolean'),
-					  'glossary_submit'  => array('title'=> LAN_GLOSSARY_OPTGEN_07,'type' => 'boolean'),
+//////////					  'glossary_submit'  => array('title'=> LAN_GLOSSARY_OPTGEN_07,'type' => 'boolean'),
 					  'glossary_submit_class'  => array('title'=> LAN_GLOSSARY_OPTGEN_08, 'type'=>'userclass'),
 					  'glossary_submit_directpost'  => array('title'=> LAN_GLOSSARY_OPTGEN_09,'type' => 'boolean'),
 					  'glossary_submit_htmlarea'  => array('title'=> LAN_GLOSSARY_OPTGEN_10,'type' => 'boolean'),

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,19 +20,16 @@ Not updated:
 - PLANNED Convert LAN files (inclunding filenames and paths) to V2 standards
 - PLANNED Change the user field. Change the old v1 (1.NAME) to V2 (1 - user id only) and use USER core functions to retrieve username...
 - PLANNED update e_list.php
+- PLANNED Rewriting of templates and shortcodes, make use of wrappers, mainly in the alphabet button filter...
 
 New functionality:
 - PLANNED Enable image (or images) in definitons. Needs to be made a custom media manager categorie (in plugin.xml) and a database field...
-- PLANNED Allow templating of the initials buttons form (used as filter when browsing definitions)
-- PLANNED Allow definition to be rendered as several options: as a link, as a link AND tooltip, as a tooltip only.
+- PLANNED Allow definition linkwords to be rendered as several options: as a link, as a link AND tooltip, as a tooltip only.
   - Enable to show link in tooltip or no...
 - PLANNED Code cleanup:
   - Delete unused functions / methods
-  - Use traits for commonly used functions (like the category select in admin area...), instead of classes...
+  - Use traits for commonly used functions, instead of classes...
   - Reuse the admin_config code to render the frontend edit / create definition form, maybe?
   - Check files / classes redundancy and overhead...
+  - Simplify code. Unnest functions inside single line functions, etc
 - PLANNED Old legacy files cleanup
-
-
-
- 

--- a/glossary_class.php
+++ b/glossary_class.php
@@ -22,8 +22,12 @@ if (!defined('e107_INIT')) { exit; }
 // OLD include_lan(e_PLUGIN."glossary/languages/".e_LANGUAGE."/Lan_".basename(__FILE__));
 e107::lan('glossary','class',true);
 
+require_once(e_PLUGIN.'glossary/glossary_trait.php');
+
 class glossary_class
 {
+  use GlossaryTrait;
+
 	var $message;
 	var $caption;
 
@@ -109,7 +113,9 @@ class glossary_class
 		return $head_sub;
 	}
 
-	function show_letter($approved)
+// Deprecated in favor of trait... No need to include and start class...
+/*
+	function show_letter($approved = 1)
 	{
 
 		$distinctwords = e107::getDb()->retrieve("glossary", " DISTINCT(glo_name) ", "glo_approved = '$approved' ORDER BY glo_name ASC", "default");
@@ -147,12 +153,14 @@ class glossary_class
 		}
 		return $text;
 	}
+*/
 	
 	function show_word($approved)
 	{
 		global $sql, $ns, $rs, $tp;
 
-		$text = $this->show_letter($approved);
+//		$text = $this->show_letter($approved);
+		$text = $this->browse_letter($approved);
 
 		$letter = (isset($_POST['letter']) ? $_POST['letter'] : "");
 		if ($letter != "" && $letter != LAN_GLOSSARY_SHOWLETT_02 )
@@ -346,20 +354,24 @@ class glossary_class
 		$ns -> tablerender($caption, $text);
 	}
 
+/* Orphan function!
 	function createWord($id)
 	{
 		$this->createDef($id, 0);
 	}
+*/
 
 	function createSubWord($id)
 	{
 		$this->createDef($id, 1);
 	}
 
+/* Orphan function!
 	function editWord($id)
 	{
 		$this->createWord($id);
 	}	
+*/
 	
 	function admin_update($update, $type, $success)
 	{
@@ -587,6 +599,7 @@ class glossary_class
 			}
 		}
 
+/*
 		$ok = 0;
 		for($i = 0; $i <= 255; $i++)
 		{
@@ -597,6 +610,7 @@ class glossary_class
 				break;
 			}
 		}
+
 
 		$wcar = "0-9";
 		if ($ok)
@@ -614,7 +628,12 @@ class glossary_class
 		}
 
 		$text2 = e107::getParser()->parseTemplate($this->plugTemplates['WORD_ALLCHAR_PRE'], FALSE).$text2.e107::getParser()->parseTemplate($this->plugTemplates['WORD_ALLCHAR_POST'], FALSE);
-		$text  = $text2.$text;
+*/
+
+//    $text2 = $this->show_letter(1);
+
+//		$text  = $text2.$text;
+		$text  = $this->browse_letter().$text;
     
     $start = e107::getParser()->parseTemplate($this->plugTemplates['WORD_PAGE_START']);
     $end   = e107::getParser()->parseTemplate($this->plugTemplates['WORD_PAGE_END']);

--- a/glossary_trait.php
+++ b/glossary_trait.php
@@ -1,0 +1,115 @@
+<?php
+if (!defined('e107_INIT')) { exit; }
+
+trait GlossaryTrait {
+	function browse_letter($approved = 1)
+	{
+		$distinctwords = e107::getDb()->retrieve("glossary", " DISTINCT(glo_name) ", "glo_approved = '$approved' ORDER BY glo_name ASC", "default");
+//    var_dump ($approved);
+		foreach($distinctwords AS $row) 
+		{
+//			$arrletters[] = $this->first_car($row['glo_name']);
+			$arrletters[] = strtoupper(mb_substr($row['glo_name'], 0, 1, 'utf-8'));
+		}
+		$distinctfirstletter = count($distinctwords);	 
+		$arrletters = array_unique($arrletters);
+//    var_dump ($arrletters);
+//		$arrletters = array_values($arrletters);
+		$arrletters = array_combine($arrletters, $arrletters);
+//    var_dump ($arrletters);
+		asort($arrletters); // Unnecessary, already sorted from mysql....
+//    var_dump ($arrletters);
+		$text = "";
+		if($distinctfirstletter != 1)
+		{
+//      var_dump(USER_AREA === true);
+		  if (USER_AREA === true){
+
+		$word_shortcodes = e107::getScBatch('glossary', 'glossary');
+
+		$ok = 0;
+		for($i = 0; $i <= 255; $i++)
+		{
+			$car = chr($i);
+//			if ($wall[$car] && (($car < 'A') || ($car > 'Z')))
+			if ($arrletters[$car] && (($car < 'A') || ($car > 'Z')))
+			{
+				$ok =1;
+				break;
+			}
+		}
+
+//    var_dump ($arrletters);
+    global $wcar;
+		$wcar = "0-9";
+/*
+		if ($ok)
+			$text .= e107::getParser()->parseTemplate($this->plugTemplates['WORD_CHAR_LINK'], FALSE, $word_shortcodes);
+		else
+			$text .= e107::getParser()->parseTemplate($this->plugTemplates['WORD_CHAR_NOLINK'], FALSE, $word_shortcodes);
+*/
+			$text .= e107::getParser()->parseTemplate($this->plugTemplates[($ok?'WORD_CHAR_LINK':'WORD_CHAR_NOLINK')], FALSE, $word_shortcodes);
+
+		for($i = ord("A"); $i <= ord("Z"); $i++)
+		{
+			$wcar = chr($i);
+//      echo " : ";
+//      var_dump ($arrletters[$wcar]);
+//      echo "<hr>";
+/*
+			if ($arrletters[$wcar])
+				$text .= e107::getParser()->parseTemplate($this->plugTemplates['WORD_CHAR_LINK'], FALSE, $word_shortcodes);
+			else
+				$text .= e107::getParser()->parseTemplate($this->plugTemplates['WORD_CHAR_NOLINK'], FALSE, $word_shortcodes);
+		}
+*/
+				$text .= e107::getParser()->parseTemplate($this->plugTemplates[($arrletters[$wcar]?'WORD_CHAR_LINK':'WORD_CHAR_NOLINK')], FALSE, $word_shortcodes);
+		}
+		$text = e107::getParser()->parseTemplate($this->plugTemplates['WORD_ALLCHAR_PRE'], FALSE).$text.e107::getParser()->parseTemplate($this->plugTemplates['WORD_ALLCHAR_POST'], FALSE);
+		}
+    else
+    {
+    	
+      $text .= "</fieldset></form><div class='e-container'>";  
+			//$text .= $rs->form_open("post", e_SELF . ($approved ? "" : "?displaySubmitted"), "letters")."			
+			$text .= e107::getForm()->open("letters", "get", e_SELF . ($approved ? "?mode=main" : "?mode=submitted"))."
+				<table id='show_letter' style='".ADMIN_WIDTH."' class='table adminlist table-striped'>
+					<thead><tr class='even'>
+						<td colspan='2' class='fcaption'>".LAN_GLOSSARY_SHOWLETT_01."</td>
+					</tr></thead>
+				<tr>
+					<td colspan='2' class='forumheader3' style='text-align: center;'>";
+
+/*
+			for($i = 0; $i < count($arrletters); $i++)
+			{
+				if($arrletters[$i]!= "")
+*/
+			foreach($arrletters as $i)
+			{
+//        var_dump ($i);
+//				if($arrletters[$i]!= "")
+				if($i!= "")
+					//$text .= $rs->form_button("submit", "letter", strtoupper($arrletters[$i]), "", "", LAN_GLOSSARY_SHOWLETT_03);
+          // form button only allows 5 options.... not 6... No tooltip available there..
+
+//var_dump ($_GET['letter'] == $arrletters[$i]);          
+//var_dump ($_GET['letter'] == $arrletters[$i]);          
+//					$text .= e107::getForm()->button("letter", strtoupper($arrletters[$i]), "submit", "", ($_GET['letter']==$arrletters[$i]?['class'=>'active', 'disabled'=>'disabled',]:''));
+					$text .= e107::getForm()->button("letter", strtoupper($i), "submit", "", ($_GET['letter']==$i?['class'=>'active', 'disabled'=>'disabled',]:''));
+			}
+
+			//$text .= "&nbsp;".$rs->form_button("submit", "letter", LAN_GLOSSARY_SHOWLETT_02, "", "", LAN_GLOSSARY_SHOWLETT_04);
+//			$text .= "&nbsp;".e107::getForm()->button( "letter", LAN_GLOSSARY_SHOWLETT_02, "submit", "", LAN_GLOSSARY_SHOWLETT_04);
+          // form button only allows 5 options.... not 6... No tooltip available there..
+
+			$text .= "&nbsp;".e107::getForm()->button( "letter", LAN_GLOSSARY_SHOWLETT_02, "submit", "", (($_GET['letter']=='All' || !$_GET['letter'])?['class'=>'active', 'disabled'=>'disabled',]:''));
+			$text .= "</td></tr></table>".e107::getForm()->close()."</div><form><fieldset>";
+    }
+    
+    }
+		return $text;
+	}
+}
+
+?>

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,9 @@
 	<pluginPrefs>
     <!--		start general prefs -->
 		<pref name="glossary_linkword">0</pref>
-		<pref name="glossary_submit">0</pref>
+    <!-- Redundant pref, can be dissabled via glossary_submit_class dropdown selction
+    		<pref name="glossary_submit">0</pref>
+    -->
  		<pref name="glossary_submit_class">255</pref>
 		<pref name="glossary_submit_directpost">0</pref>
 		<pref name="glossary_submit_htmlarea">0</pref>

--- a/shortcodes/batch/glossary_shortcodes.php
+++ b/shortcodes/batch/glossary_shortcodes.php
@@ -71,7 +71,7 @@ class plugin_glossary_glossary_shortcodes extends e_shortcode
 	}
   /* reason: to use shortcode wrapper */ 
 	public function sc_word_char($parm = NULL) {
-		global $wcar;;
+		global $wcar;
 		return $wcar;
 	}  
 	
@@ -81,7 +81,8 @@ class plugin_glossary_glossary_shortcodes extends e_shortcode
 		{                              
 			$adop_icon = (file_exists(THEME."generic/newsedit.png") ? "<img src='".THEME."generic/newsedit.png"."'  alt='' style='border:0' />"
        : "<icon class='fa fa-edit'></icon>");
-			return " <a href='".e_PLUGIN."glossary/admin_config_old.php?edit.".$glo_id."' target='_blank' title='".LAN_GLOSSARY_ADMINOPTIONS_01."'>".$adop_icon."</a>\n";
+//			return " <a href='".e_PLUGIN."glossary/admin_config_old.php?edit.".$glo_id."' target='_blank' title='".LAN_GLOSSARY_ADMINOPTIONS_01."'>".$adop_icon."</a>\n";
+			return " <a href='".e_PLUGIN."glossary/admin_config.php?mode=main&action=edit&id=".$glo_id."' target='_blank' title='".LAN_GLOSSARY_ADMINOPTIONS_01."'>".$adop_icon."</a>\n";
 		}
 		else
 			return "";
@@ -113,7 +114,8 @@ class plugin_glossary_glossary_shortcodes extends e_shortcode
 		$text = "";
 		$mains = "";
 		$baseurl = e_PLUGIN."glossary/glossaire.php";
-		if(isset($pref['glossary_page_link_submit']) && $pref['glossary_page_link_submit'] && isset($pref['glossary_submit']) && $pref['glossary_submit'] && check_class($pref['glossary_submit_class']))
+/////		if(isset($pref['glossary_page_link_submit']) && $pref['glossary_page_link_submit'] && isset($pref['glossary_submit']) && $pref['glossary_submit'] && check_class($pref['glossary_submit_class']))
+		if(isset($pref['glossary_page_link_submit']) && $pref['glossary_page_link_submit'] && $pref['glossary_submit'] && check_class($pref['glossary_submit_class']))
 		{
 			$direct = (isset($pref['glossary_submit_directpost']) && $pref['glossary_submit_directpost']) ? 1 : 0;
 			if(isset($pref['glossary_page_link_rendertype']) && $pref['glossary_page_link_rendertype'] == "1")
@@ -159,7 +161,8 @@ class plugin_glossary_glossary_shortcodes extends e_shortcode
 				$mains .= $bullet."&nbsp;<a href='".$baseurl."'>".LAN_GLOSSARY_BLMENU_02."</a>";
 		}
 		
-		if(isset($pref['glossary_menu_link_submit']) && $pref['glossary_menu_link_submit'] && isset($pref['glossary_submit']) && $pref['glossary_submit'] && check_class($pref['glossary_submit_class']))
+/////		if(isset($pref['glossary_menu_link_submit']) && $pref['glossary_menu_link_submit'] && isset($pref['glossary_submit']) && $pref['glossary_submit'] && check_class($pref['glossary_submit_class']))
+		if(isset($pref['glossary_menu_link_submit']) && $pref['glossary_menu_link_submit'] && $pref['glossary_submit'] && check_class($pref['glossary_submit_class']))
 		{
 			$direct = (isset($pref['glossary_submit_directpost']) && $pref['glossary_submit_directpost']) ? 1 : 0;
 			if(isset($pref['glossary_menu_link_rendertype']) && $pref['glossary_menu_link_rendertype'] == "1")


### PR DESCRIPTION
- Wrong frontend link to edit definition corrected. It currently only works with admin, and that's how it was in old plugin. To be reworked to be available as stated by prefs...
- Reworked alphabetic words sort php code. Implemented as trait, but candidate for future rework and simplification... Templating is already donne in frontend....
- Removed "dead" functions....
- Enabled WYSIWYG area per preferences on definition creation and edit...
- Removed unecessary old redundant pref...